### PR TITLE
Add translation capabilities (Kor prompt --> Eng) for better performance

### DIFF
--- a/config.py
+++ b/config.py
@@ -47,6 +47,14 @@ OPENSEARCH_HEADERS = {
     "Content-Type": "application/json",
 }
 
+# Translation Configuration
+KOREAN_DETECTION_THRESHOLD = 0.5  # Ratio of Korean characters to consider text as Korean
+TRANSLATION_MODEL_NAME = "Helsinki-NLP/opus-mt-ko-en"  # MarianMT model for Korean to English translation
+
+# LLM Configuration
+LLM_MODEL_NAME = "gpt-4o-mini"  # OpenAI model to use
+LLM_TEMPERATURE = 0  # Temperature for LLM responses
+
 # Available OpenSearch indices used in the application:
 # - chat-history: Stores chat history between users and the chatbot
 # - user-photos: Stores user uploaded photos

--- a/libs/translation_handler.py
+++ b/libs/translation_handler.py
@@ -1,0 +1,36 @@
+from typing import Dict, Tuple
+import re
+from transformers import MarianMTModel, MarianTokenizer
+from config import KOREAN_DETECTION_THRESHOLD, TRANSLATION_MODEL_NAME
+
+class TranslationHandler:
+    def __init__(self):
+        # Initialize Korean to English translation model
+        self.ko_en_model_name = TRANSLATION_MODEL_NAME
+        self.ko_en_tokenizer = MarianTokenizer.from_pretrained(self.ko_en_model_name)
+        self.ko_en_model = MarianMTModel.from_pretrained(self.ko_en_model_name)
+
+    def detect_language(self, text: str) -> Tuple[bool, float]:
+        """Detect if text contains Korean characters using regex"""
+        # Check for Korean Unicode range (Hangul Syllables and Hangul Jamo)
+        korean_pattern = re.compile('[가-힣ㄱ-ㅎㅏ-ㅣ]')
+        korean_ratio = len(korean_pattern.findall(text)) / len(text.replace(" ", ""))
+        is_korean = korean_ratio > KOREAN_DETECTION_THRESHOLD
+        return is_korean, korean_ratio
+
+    def translate_to_english(self, text: str) -> str:
+        """Translate Korean text to English using MarianMT"""
+        inputs = self.ko_en_tokenizer(text, return_tensors="pt", padding=True, truncation=True)
+        translated = self.ko_en_model.generate(**inputs)
+        return self.ko_en_tokenizer.decode(translated[0], skip_special_tokens=True)
+
+    def process_text(self, text: str) -> Tuple[str, bool]:
+        """Process input text, translating if necessary"""
+        is_korean, _ = self.detect_language(text)
+        if is_korean:
+            translated = self.translate_to_english(text)
+            return translated, True
+        return text, False
+
+# Singleton instance
+translator = TranslationHandler() 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,6 @@ langchain
 langchain-openai
 langchain-community
 pytest
+transformers
+torch
+sentencepiece  # Required for MarianMT tokenizer

--- a/sandbox/eng-kor-translation.ipynb
+++ b/sandbox/eng-kor-translation.ipynb
@@ -1,0 +1,105 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 한글 영어 번역 데모\n",
+    "\n",
+    "- huggingface 모델 사용\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hello, please translate this sentence into English.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from transformers import MarianMTModel, MarianTokenizer\n",
+    "\n",
+    "# Load the model and tokenizer\n",
+    "model_name = \"Helsinki-NLP/opus-mt-ko-en\"\n",
+    "tokenizer = MarianTokenizer.from_pretrained(model_name)\n",
+    "model = MarianMTModel.from_pretrained(model_name)\n",
+    "\n",
+    "# Translate text\n",
+    "def translate_korean_to_english(text):\n",
+    "    inputs = tokenizer(text, return_tensors=\"pt\", padding=True, truncation=True)\n",
+    "    translated = model.generate(**inputs)\n",
+    "    return tokenizer.decode(translated[0], skip_special_tokens=True)\n",
+    "\n",
+    "korean_prompt = \"안녕하세요. 이 문장을 영어로 번역해주세요.\"\n",
+    "english_prompt = translate_korean_to_english(korean_prompt)\n",
+    "print(english_prompt)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "고용.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from transformers import MarianMTModel, MarianTokenizer\n",
+    "\n",
+    "# Load the model and tokenizer for English-to-Korean translation\n",
+    "model_name = \"Helsinki-NLP/opus-mt-tc-big-en-ko\"\n",
+    "tokenizer = MarianTokenizer.from_pretrained(model_name)\n",
+    "model = MarianMTModel.from_pretrained(model_name)\n",
+    "\n",
+    "# Translate text from English to Korean\n",
+    "def translate_english_to_korean(text):\n",
+    "    inputs = tokenizer(text, return_tensors=\"pt\", padding=True, truncation=True)\n",
+    "    translated = model.generate(**inputs)\n",
+    "    return tokenizer.decode(translated[0], skip_special_tokens=True)\n",
+    "\n",
+    "english_prompt = \"Hello There.\"\n",
+    "korean_prompt = translate_english_to_korean(english_prompt)\n",
+    "print(korean_prompt)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "llm312",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -1,0 +1,71 @@
+import pytest
+from libs.translation_handler import translator
+
+TEST_CASES = [
+    # (input_text, expected_is_korean)
+    ("안녕하세요", True),
+    ("Hello, how are you?", False),
+    ("오늘 날씨가 좋네요", True),
+    ("Mixed 한글 and English", False),  # 한글 비율이 낮아서 한글로 판단하지 않음
+    ("Today is a good day", False),
+]
+
+@pytest.mark.parametrize("text,expected_is_korean", TEST_CASES)
+def test_language_detection(text: str, expected_is_korean: bool):
+    """Test language detection functionality"""
+    is_korean, confidence = translator.detect_language(text)
+    print(f"\nTesting text: {text}")
+    print(f"Detected Korean: {is_korean} (confidence: {confidence})")
+    
+    assert is_korean == expected_is_korean
+    assert 0 <= confidence <= 1
+
+def test_translation():
+    """Test Korean to English translation"""
+    korean_texts = [
+        "안녕하세요, 오늘 날씨가 좋네요",
+        "내일 일정을 알려주세요",
+        "사진을 보여주세요"
+    ]
+    
+    print("\nTesting translations:")
+    for text in korean_texts:
+        translated, was_translated = translator.process_text(text)
+        print(f"\nKorean: {text}")
+        print(f"English: {translated}")
+        
+        assert was_translated
+        assert translated != text
+        assert len(translated) > 0
+
+def test_end_to_end_flow():
+    """Test the complete translation flow with different inputs"""
+    test_inputs = [
+        ("Hello, how are you?", False),  # English input
+        ("안녕하세요, 날씨가 좋네요", True),  # Korean input
+        ("Show me the schedule", False),  # English command
+        ("일정 보여주세요", True),  # Korean command
+    ]
+    
+    print("\nTesting end-to-end flow:")
+    for text, should_translate in test_inputs:
+        translated, was_translated = translator.process_text(text)
+        print(f"\nInput: {text}")
+        print(f"Output: {translated}")
+        print(f"Was translated: {was_translated}")
+        
+        assert was_translated == should_translate
+        if not should_translate:
+            assert translated == text
+
+if __name__ == "__main__":
+    # Run tests with more detailed output
+    print("Running language detection tests...")
+    for text, expected in TEST_CASES:
+        test_language_detection(text, expected)
+    
+    print("\nRunning translation tests...")
+    test_translation()
+    
+    print("\nRunning end-to-end flow tests...")
+    test_end_to_end_flow() 


### PR DESCRIPTION
한글로 프롬프트 입력시 영어로 번역해 LLM에 넣어줘 더 좋은 답변을 받도록 유도. 

다만, 한글 --> 영어는 LLM API 안쓰고 가벼운 로컬 모델을 huggingface 에서 찾았는데 (헬싱키 NLP 연구소꺼) 반대로 이 연구소의 영어 --> 한글 모델은 전혀 작동하지 않는 문제가 있어 임시로 LLM에게 답변 줄 때는 꼭 한글로 주라고 시킴. 